### PR TITLE
Handle case where context has no user identifier

### DIFF
--- a/feature_flipper/templatetags/feature_flipper.py
+++ b/feature_flipper/templatetags/feature_flipper.py
@@ -57,4 +57,4 @@ class FlipperNode(template.Node):
             return key[1:-1]
         if key in string.digits:
             return int(key)
-        return context[key]
+        return context.get(key, False)

--- a/feature_flipper/templatetags/feature_flipper.py
+++ b/feature_flipper/templatetags/feature_flipper.py
@@ -43,8 +43,11 @@ class FlipperNode(template.Node):
         """
         user = self._get_value(self.user_key, context)
         feature = self._get_value(self.feature, context)
-        allowed = show_feature(user, feature)
 
+        if feature is None:
+            return ''
+
+        allowed = show_feature(user, feature)
         return self.nodelist.render(context) if allowed else ''
 
     def _get_value(self, key, context):
@@ -57,4 +60,4 @@ class FlipperNode(template.Node):
             return key[1:-1]
         if key in string.digits:
             return int(key)
-        return context.get(key, False)
+        return context.get(key, None)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email='scott.walton@mypebble.co.uk',
     description='A simple, customisable, feature flipper',
     url='https://github.com/mypebble/django-feature-flipper.git',
-    version='0.0.7',
+    version='0.0.8',
     packages=find_packages(),
     license='MIT',
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
This PR stops `feature-flipper` from throwing a `KeyError` exception when the template tag's "user identifier" argument isn't contained in the page context